### PR TITLE
Update VCForm.cs

### DIFF
--- a/XLForms.cs/VCForm.cs
+++ b/XLForms.cs/VCForm.cs
@@ -139,6 +139,7 @@ namespace XLForms
                     list1 = lists[0];
                     Listlabel1.Text = list1.name;
                     ListDDL1.DataSource = list1.items;
+                    ListDDL1.SelectedItem = null;
 
                     Listlabel1.Visible = true;
                     ListDDL1.Visible = true;


### PR DESCRIPTION
Mark has asked whether we can nullify the default selection to avoid users accidentally indexing to an incorrect document type. When you have some free time, could you possibly let me know if you approve of the change?

Thanks

Tom